### PR TITLE
fix: Remove https:// schema from URL destinations in EIA sample policies

### DIFF
--- a/Samples/EIA/sample_policies.rename_to_csv
+++ b/Samples/EIA/sample_policies.rename_to_csv
@@ -1,6 +1,6 @@
 PolicyName,PolicyType,PolicyAction,Description,RuleType,RuleDestinations,RuleName,Provision
 Dev_Tools-Allow,WebContentFiltering,Allow,Allow development tools and resources,FQDN,github.com;*.github.io;stackoverflow.com;*.stackexchange.com,GitHub_StackOverflow,yes
-Dev_Tools-Allow,WebContentFiltering,Allow,Allow development tools and resources,URL,https://docs.microsoft.com/*;https://learn.microsoft.com/*,Microsoft_Docs,yes
+Dev_Tools-Allow,WebContentFiltering,Allow,Allow development tools and resources,URL,docs.microsoft.com/*;learn.microsoft.com/*,Microsoft_Docs,yes
 Dev_Tools-Allow,WebContentFiltering,Allow,Allow development tools and resources,webCategory,CodeRepositories,Dev_Categories,yes
 Social_Media-Block,WebContentFiltering,Block,Block social media and entertainment sites,webCategory,SocialNetworking;Entertainment;Games,Social_Entertainment_Block,yes
 Social_Media-Block,WebContentFiltering,Block,Block social media and entertainment sites,FQDN,facebook.com;*.facebook.com;twitter.com;*.twitter.com;instagram.com;*.instagram.com,Popular_Social_Sites,yes


### PR DESCRIPTION
URL destinations in Graph API filteringPolicies must contain only authority and path parts (no schema, port, query, or fragment). 

This fix removes the https:// prefix from example Microsoft Docs/Learn destinations in the sample policies CSV template.

**Error encountered during provisioning:**
- HTTP 400: "URL destination should contain only authority and path parts (no schema, not port, no query, no fragment)"

**Change:**
- Line 3: `https://docs.microsoft.com/*;https://learn.microsoft.com/*` → `docs.microsoft.com/*;learn.microsoft.com/*`

**Testing:** Verified in a greenfield Entra Internet Access deployment using Start-EntraInternetAccessProvisioning.